### PR TITLE
[BE] Jackson 적용하여 Result 클래스 대신 JSON 데이터를 반환하도록 변경

### DIFF
--- a/BE-workspace/.idea/gradle.xml
+++ b/BE-workspace/.idea/gradle.xml
@@ -4,6 +4,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="delegatedBuild" value="true" />
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="/usr/local/Cellar/gradle/6.1.1_1/libexec" />

--- a/BE-workspace/src/main/java/com/codesquad/signup4/controller/APIUserController.java
+++ b/BE-workspace/src/main/java/com/codesquad/signup4/controller/APIUserController.java
@@ -4,47 +4,60 @@ import com.codesquad.signup4.domain.User;
 import com.codesquad.signup4.domain.UserRepository;
 import com.codesquad.signup4.dto.Result;
 import com.codesquad.signup4.exception.BadRequestException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
 public class APIUserController {
-    @Autowired
-    UserRepository userRepository;
 
-    @PostMapping("/create")
-    public Result create(User newUser) {
+  @Autowired
+  UserRepository userRepository;
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  @PostMapping("/create")
+  public String create(User newUser) throws JsonProcessingException {
 //        Todo 일단 이렇게 작성만 해놓음
-        if(newUser.getUserId() == null) {
-            throw new BadRequestException();
-        }
-        return Result.ok();
+    if (newUser.getUserId() == null) {
+      throw new BadRequestException();
+    }
+    return okResultProvider();
+  }
+
+  @GetMapping("/checkId")
+  public String checkId(@RequestParam String id) throws JsonProcessingException {
+    if (id == null) {
+      throw new BadRequestException();
     }
 
-    @GetMapping("/checkId")
-    public Result checkId(@RequestParam String id) {
-        if(id == null) {
-            throw new BadRequestException();
-        }
+    if (id.equals("testUserId")) {
+      return failResultProvider("중복된 아이디입니다.");
+    }
+    return okResultProvider();
+  }
 
-        if(id.equals("testUserId")) {
-            return Result.fail("중복된 아이디입니다.");
-        }
-
-        return Result.ok();
+  @GetMapping("/checkMobile")
+  public String checkMobile(@RequestParam String mobileNumber) throws JsonProcessingException {
+    if (mobileNumber == null) {
+      throw new BadRequestException();
     }
 
-    @GetMapping("/checkMobile")
-    public Result checkMobile(@RequestParam String mobileNumber) {
-        if(mobileNumber == null) {
-            throw new BadRequestException();
-        }
-
-        if(mobileNumber.equals("01012341234")) {
-            return Result.fail("중복된 번호입니다.");
-        }
-
-        return Result.ok();
+    if (mobileNumber.equals("01012341234")) {
+        return failResultProvider("중복된 번호입니다.");
     }
+    return okResultProvider();
+  }
+
+  public String okResultProvider() throws JsonProcessingException {
+    Result okResult = Result.ok();
+    return objectMapper.writeValueAsString(okResult);
+  }
+
+  public String failResultProvider(String errorMessage) throws JsonProcessingException {
+      Result failResult = Result.fail(errorMessage);
+      return objectMapper.writeValueAsString(failResult);
+  }
 }

--- a/BE-workspace/src/main/java/com/codesquad/signup4/domain/User.java
+++ b/BE-workspace/src/main/java/com/codesquad/signup4/domain/User.java
@@ -1,12 +1,22 @@
 package com.codesquad.signup4.domain;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.io.Serializable;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.MappedCollection;
 
 import java.util.List;
 import java.util.Objects;
 
-public class User {
+@JsonInclude(Include.NON_NULL)
+public class User implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public User() {
+        super();
+    }
 
     @Id
     private Long id;
@@ -29,6 +39,7 @@ public class User {
     private List<Interest> interest;
 
     public User(String userId, String password, String email, String gender, String username, String birthDate, String mobile) {
+        super();
         this.userId = userId;
         this.password = password;
         this.email = email;

--- a/BE-workspace/src/test/java/com/codesquad/signup4/APIControllerTest.java
+++ b/BE-workspace/src/test/java/com/codesquad/signup4/APIControllerTest.java
@@ -1,0 +1,57 @@
+package com.codesquad.signup4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.codesquad.signup4.domain.User;
+import com.codesquad.signup4.domain.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class APIControllerTest {
+
+  @Autowired
+  private TestRestTemplate testRestTemplate;
+
+  @LocalServerPort
+  private int port;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  //동작하지 않는 테스트입니다.
+  @Test
+  public void CreateAPITest() throws JsonProcessingException {
+    String posturl = "http://localhost:" + port + "create";
+    String inputJSON = "{\"userId\":\"javajigi\",\"password\":\"password\",\"email\":\"javajigi@gmail.com\",\"gender\":\"여자\",\"username\":\"testUserName\",\"birthDate\":\"2020-01-01\",\"mobile\":\"01012341234\",\"interest\":[{\"id\":1,\"interestName\":\"soccer\"},{\"id\":2,\"interestName\":\"shopping\"}]}\n";
+    //여기서 실제로는 어떻게 interest를 받아서 처리할 지 고민해야 할 것 같습니다.
+    User expectedJavajigi = User.create("javajigi", "password", "javajigi@gmail.com", "여자", "testUserName", "2020-01-01", "01012341234");
+    User javajigi = objectMapper.readValue(inputJSON, User.class);
+    ResponseEntity<Object> createResponseEntity = testRestTemplate.postForEntity(posturl, javajigi, Object.class);
+
+    //{
+    //	“userId” : “javajigi”,
+    //	“password” : “password”,
+    //	“email” : “javajigi@gmail.com”,
+    //	“gender” : “여자”,
+    //	“username” : “testUserName”,
+    //	“birthDate” : “2020-01-01”,
+    //	“mobile” : “01012341234”,
+    //	“interest” : “??”
+    //}
+
+    assertEquals(javajigi, expectedJavajigi);
+    assertNotNull(createResponseEntity);
+    System.out.println(createResponseEntity);
+  }
+}

--- a/BE-workspace/src/test/java/com/codesquad/signup4/Signup4ApplicationTests.java
+++ b/BE-workspace/src/test/java/com/codesquad/signup4/Signup4ApplicationTests.java
@@ -3,6 +3,8 @@ package com.codesquad.signup4;
 import com.codesquad.signup4.domain.Interest;
 import com.codesquad.signup4.domain.User;
 import com.codesquad.signup4.domain.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +21,7 @@ class Signup4ApplicationTests {
 	private UserRepository userRepository;
 
 	@Test
-	void H2_데이터베이스에_USER가_저장된다() {
+	void USER가_저장된다() throws JsonProcessingException {
 		User javajigi = User.create("javajigi", "password", "javajigi@gmail.com", "여자", "testUserName", "2020-01-01", "01012341234");
 		List<Interest> interest = new ArrayList<>();
 		interest.add(new Interest("soccer"));
@@ -30,6 +32,23 @@ class Signup4ApplicationTests {
 		User user = userRepository.findById(javajigi.getId()).get();
 		System.out.println(user);
 		Assertions.assertEquals(javajigi, user);
+	}
 
+	@Test
+	void USER가_JSON으로_변환된다() throws JsonProcessingException {
+		User javajigi = User.create("javajigi", "password", "javajigi@gmail.com", "여자", "testUserName", "2020-01-01", "01012341234");
+		List<Interest> interest = new ArrayList<>();
+		interest.add(new Interest("soccer"));
+		interest.add(new Interest("shopping"));
+		javajigi.addInterest(interest);
+		userRepository.save(javajigi);
+
+		User savedJavajigi = userRepository.findById(javajigi.getId()).get();
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		String savedjavajigiAsString = objectMapper.writeValueAsString(savedJavajigi);
+		String expected = "{\"userId\":\"javajigi\",\"password\":\"password\",\"email\":\"javajigi@gmail.com\",\"gender\":\"여자\",\"username\":\"testUserName\",\"birthDate\":\"2020-01-01\",\"mobile\":\"01012341234\",\"interest\":[{\"id\":1,\"interestName\":\"soccer\"},{\"id\":2,\"interestName\":\"shopping\"}]}\n";
+
+		Assertions.assertEquals(expected, savedjavajigiAsString);
 	}
 }


### PR DESCRIPTION
## 작업사항
* Jackson 라이브러리 적용
* API에서 요청 성공 시 Result.ok 클래스를 JSON 데이터로 형식 변경하여 반환하도록 구조 변경
* API에서 요청 실패 시 Result.fail 클래스를 JSON 데이터로 형식 변경하여 반환하도록 구조 변경
* 테스트 설계내용 검증: USER가_JSON으로_변환된다() 메소드에서 JSON 텍스트로 반환 여부 확인 가능

## 추가로 작업해야 하는 사항
* TestRestTemplate을 활용하여 JUnit 테스트 자체에서 API 성공/실패 여부를 테스트하고자 함
* 해당 테스트는 APIControllerTest의 CreateAPITest()에 작성하였음
* 하지만 ```cannot deserialize from Object value (no delegate- or property-based Creator)``` 오류가 발생하는데, 이 이유는 JSON 데이터를 받아 User 인스턴스를 생성할 때 Interest의 경우에는 함께 처리하지 않고 따로 addInterest 메소드를 활용하기 때문으로 추정됨. 이것을 실제 JSON 데이터로 넘어올 때는 어떻게 파싱해서 별도로 메소드를 실행해야 할 지 고민해야 할 것임.